### PR TITLE
Fixed spelling errors, renamed variables/methods, and updated corresp…

### DIFF
--- a/docs/ParticleModule.rst
+++ b/docs/ParticleModule.rst
@@ -5,7 +5,7 @@ Using NytoModule, creating a module automatically updates its version. The under
 
 However, this feature is not commonly used, and for the sake of such functionality, there is a sacrifice in performance.
 
-.. image:: ./image/particle_kernal.png
+.. image:: ./image/particle_kernel.png
 		:width: 500
 
 From the particle structure diagram, a circular reference structure can be observed, which can cause memory pressure for programming languages like Python that use garbage collection. We can conduct a simple experiment to observe the process from initializing a particle to reclaiming it in Python::
@@ -114,22 +114,22 @@ Below is part of the code for ParticleModule, which shows that ParticleModule is
         def __init__(self, root_module: Tmodule) -> None:
             ...
             super().__init__()
-            self.particle_kernal: ParticleKernalImp = root_module._particle_kernal
+            self.particle_kernel: ParticleKernelImp = root_module._particle_kernel
             self.root_module: Tmodule = root_module
-            self.clear_kernal_ref()
+            self.clear_kernel_ref()
         
         def forward(self, *args, **kwargs):
             return self.root_module(*args, **kwargs)
             
-        def clear_kernal_ref(self) -> None:
+        def clear_kernel_ref(self) -> None:
             for submodule in self.root_module.modules():
                 if isinstance(submodule, NytoModuleBase):
-                    submodule._particle_kernal = None
+                    submodule._particle_kernel = None
                 
-        def restore_kernal_ref(self) -> None:
+        def restore_kernel_ref(self) -> None:
             for submodule in self.root_module.modules():
                 if isinstance(submodule, NytoModuleBase):
-                    submodule._particle_kernal = self.particle_kernal
+                    submodule._particle_kernel = self.particle_kernel
             
         ...
 
@@ -178,14 +178,14 @@ You can access the original model through the ``root_module`` attribute::
       (layer2): Linear(in_features=12, out_features=3, bias=True)
     )
 
-However, it's recommended not to perform any direct operations on the original model since the reference to the particle kernel has been cleared. If necessary, you can restore the reference to the particle kernel using the ``restore_kernal_ref()`` method and clear the reference using the ``clear_kernal_ref()`` method::
+However, it's recommended not to perform any direct operations on the original model since the reference to the particle kernel has been cleared. If necessary, you can restore the reference to the particle kernel using the ``restore_kernel_ref()`` method and clear the reference using the ``clear_kernel_ref()`` method::
 
-    >>> net.restore_kernal_ref()
-    >>> net.root_module._particle_kernal is None
+    >>> net.restore_kernel_ref()
+    >>> net.root_module._particle_kernel is None
     False
     
-    net.clear_kernal_ref()
-    >>> net.root_module._particle_kernal is None
+    net.clear_kernel_ref()
+    >>> net.root_module._particle_kernel is None
     True
 
 
@@ -449,7 +449,7 @@ Using ParticleModule::
     class MyPMProduct(PMProduct):
         @classmethod
         def from_ParamProduct(cls, product: 'ParamProduct') -> PMProduct:
-            return MyPMProduct(product.kernal, 
+            return MyPMProduct(product.kernel, 
                                product.module_id, 
                                product.params)
 
@@ -469,9 +469,9 @@ Using ParticleModule::
             print(f"delete cnn={self.module_id}")   
 
         def product(self) -> MyPMProduct:
-            return MyPMProduct(self.particle_kernal, 
+            return MyPMProduct(self.particle_kernel, 
                                ROOT_MODULE_ID, 
-                               self.particle_kernal.data.params)
+                               self.particle_kernel.data.params)
 
     def particle_operation_loop10():
         net = MyParticleModule(CNN())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ copyright = '2024, jimmyzzzz'
 author = 'jimmyzzzz'
 
 # The full version, including alpha/beta/rc tags
-release = '1.0.0'
+release = '1.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/nytorch.rst
+++ b/docs/nytorch.rst
@@ -9,10 +9,10 @@ nytorch.base module
    :undoc-members:
    :show-inheritance:
 
-nytorch.kernal module
+nytorch.kernel module
 ---------------------
 
-.. automodule:: nytorch.kernal
+.. automodule:: nytorch.kernel
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/particle.rst
+++ b/docs/particle.rst
@@ -8,7 +8,7 @@ if you encounter problems in model construction,
 the content of this chapter may provide you with answers.
 
 
-Particle kernal
+Particle kernel
 ------------------
 
 .. note::
@@ -63,7 +63,7 @@ we must understand the program structure of particles.
 
 Below is an example of a particle structure diagram.
 
-.. image:: ./image/particle_kernal.png
+.. image:: ./image/particle_kernel.png
 		:width: 500
 
 And the corresponding code::
@@ -102,13 +102,13 @@ here is an example::
 
 ::
 
-    >>> module1._particle_kernal is module2._particle_kernal
+    >>> module1._particle_kernel is module2._particle_kernel
     True
     
-    >>> module1._particle_kernal is module3._particle_kernal
+    >>> module1._particle_kernel is module3._particle_kernel
     False
     
-    >>> module3._particle_kernal is module4._particle_kernal
+    >>> module3._particle_kernel is module4._particle_kernel
     True
 
 This also answers our second question, that is, each module can only belong to one particle.
@@ -129,14 +129,14 @@ From the structural diagram, we can know that the ParticleKernel instance has tw
 which can obtain the Module and Parameter belonging to the particle,
 they are saved in the corresponding OrderedDict::
 
-    >>> module1._particle_kernal.data.modules
+    >>> module1._particle_kernel.data.modules
     OrderedDict([(0,
                   RootModule(
                     (sub_module): SubModule()
                   )),
                  (1, SubModule())])
              
-    >>> module1._particle_kernal.data.params
+    >>> module1._particle_kernel.data.params
     OrderedDict([(0,
                   Parameter containing:
                   tensor([0.], requires_grad=True)),
@@ -249,7 +249,7 @@ The reason for these warnings is to facilitate the removal of unused modules. Co
     root = ModuleA()
     del root.b
     
-When we delete the reference to ``root.b``, we lose access to the instances of ``ModuleB`` and ``ModuleC``, making them potentially eligible for cleanup by Python's garbage collector. However, since we can still access the corresponding instances through ``root._particle_kernal``, they may not be cleared by Python's garbage collector, which is problematic.
+When we delete the reference to ``root.b``, we lose access to the instances of ``ModuleB`` and ``ModuleC``, making them potentially eligible for cleanup by Python's garbage collector. However, since we can still access the corresponding instances through ``root._particle_kernel``, they may not be cleared by Python's garbage collector, which is problematic.
 
 Our approach is to identify modules that cannot be accessed from the root module after a reference deletion and then remove them.
 
@@ -351,10 +351,10 @@ More accurately, the submodule is added to another particle. Both particles will
 
 Since the submodule can only point to one particle, it must relinquish its original particle::
 
-	>>> sub_module._particle_kernal is root1._particle_kernal
+	>>> sub_module._particle_kernel is root1._particle_kernel
 	False
 	
-	>>> sub_module._particle_kernal is root2._particle_kernal
+	>>> sub_module._particle_kernel is root2._particle_kernel
 	True
 
 Of course, encountering this warning during particle construction doesn't necessarily mean the final particle is flawed. Here's an example::
@@ -383,7 +383,7 @@ Of course, encountering this warning during particle construction doesn't necess
     def checking_references(root: base.NytoModuleBase):
         for submodule in root.modules():
             if isinstance(submodule, base.NytoModuleBase):
-                assert submodule._particle_kernal is root._particle_kernal
+                assert submodule._particle_kernel is root._particle_kernel
 
     root = ModuleC()
     checking_references(root)  # PASS
@@ -464,7 +464,7 @@ Identify which submodules point to other particles using the following example f
         suspicious_submodules: set[str] = set()
         for name, submodule in net.named_modules():
             if not isinstance(submodule, base.NytoModuleBase): continue
-            if submodule._particle_kernal is net._particle_kernal: continue
+            if submodule._particle_kernel is net._particle_kernel: continue
             suspicious_submodules.add(name)
         return suspicious_submodules
 

--- a/docs/particle_version.rst
+++ b/docs/particle_version.rst
@@ -88,7 +88,7 @@ We can access the version instance pointed to by a particle using ``_version_ker
     net1 = Linear(1, 2)
     net2 = net1.randn()
     
-    version_before_del = net1._version_kernal
+    version_before_del = net1._version_kernel
    
 When the metadata is modified,
 the system records relevant information and saves it to a version instance.
@@ -96,7 +96,7 @@ Simultaneously, a new version instance is created as the latest version::
 
 	del net1.weight
 
-	version_after_del = net1._version_kernal
+	version_after_del = net1._version_kernel
 	
 ::
 
@@ -108,7 +108,7 @@ At this point, we observe that the metadata of ``net1`` has changed, and the ver
 	>>> hasattr(net2, 'weight')
 	True
 
-	>>> version_before_del is net2._version_kernal
+	>>> version_before_del is net2._version_kernel
 	True
 
 To upgrade ``net2`` to the latest version, we can call the ``touch()`` method. Nytorch automatically updates the particle to the latest version based on the previously recorded modification information::
@@ -120,7 +120,7 @@ To upgrade ``net2`` to the latest version, we can call the ``touch()`` method. N
 	>>> hasattr(net2, 'weight')
 	False
 
-	>>> version_after_del is net2._version_kernal
+	>>> version_after_del is net2._version_kernel
 	True
 
 In practical use, frequent use of ``touch()`` is unnecessary because whenever a particle operation or metadata modification occurs, ``touch()`` is automatically invoked to ensure the particle is at the latest version.

--- a/nytorch/__init__.py
+++ b/nytorch/__init__.py
@@ -1,5 +1,5 @@
 
-from nytorch import kernal
+from nytorch import kernel
 from nytorch import mtype
 from nytorch import utils
 from nytorch import base

--- a/nytorch/kernel.py
+++ b/nytorch/kernel.py
@@ -16,7 +16,7 @@ class VersionData(abc.ABC, Generic[Tvdata, Tpdata]):
     Abstract base class for storing metadata of particles.
 
     This class is responsible for storing the metadata of particles, specifically the metadata of the species 
-    to which the particle belongs. It is essential for particle operations and will be stored in `VersionKernal.data`.
+    to which the particle belongs. It is essential for particle operations and will be stored in `VersionKernel.data`.
 
     Once an instance is created, its content remains unchanged. When new metadata is required, a copy is created 
     and modifications are applied to the new instance.
@@ -33,14 +33,14 @@ class VersionData(abc.ABC, Generic[Tvdata, Tpdata]):
     """
     
     @abc.abstractmethod
-    def init_kernal(self, kernal: 'VersionKernal') -> None:
+    def init_kernel(self, kernel: 'VersionKernel') -> None:
         """
-        Initializes the version kernal before creating a new version.
+        Initializes the version kernel before creating a new version.
 
-        This method ensures that the `VersionKernal` is properly initialized and ready to store this instance.
+        This method ensures that the `VersionKernel` is properly initialized and ready to store this instance.
 
         Args:
-            kernal (VersionKernal): The `VersionKernal` instance that will store this instance.
+            kernel (VersionKernel): The `VersionKernel` instance that will store this instance.
         """
         return 
     
@@ -75,7 +75,7 @@ class ParticleData(abc.ABC, Generic[Tvdata, Tpdata]):
     Abstract base class for storing parameters of particles.
 
     This class stores references to all parameters of the corresponding particle. It is essential for particle 
-    operations and will be stored in `ParticleKernal.data`.
+    operations and will be stored in `ParticleKernel.data`.
 
     A corresponding subclass of `VersionData` should be defined when instantiating this class, as shown below:
 
@@ -89,14 +89,14 @@ class ParticleData(abc.ABC, Generic[Tvdata, Tpdata]):
     """
 
     @abc.abstractmethod
-    def init_kernal(self, kernal: ParticleKernal) -> None:
+    def init_kernel(self, kernel: ParticleKernel) -> None:
         """
-        Initializes the particle kernal before creating a new particle.
+        Initializes the particle kernel before creating a new particle.
 
-        This method ensures that the `ParticleKernal` is properly initialized and ready to store this instance.
+        This method ensures that the `ParticleKernel` is properly initialized and ready to store this instance.
 
         Args:
-            kernal (ParticleKernal): The `ParticleKernal` instance that will store this instance.
+            kernel (ParticleKernel): The `ParticleKernel` instance that will store this instance.
         """
         return  
     
@@ -118,13 +118,13 @@ class ParticleData(abc.ABC, Generic[Tvdata, Tpdata]):
 
 class VersionUpdater(abc.ABC, Generic[Tvdata, Tpdata]):
     r"""
-    Abstract base class for tools that update VersionKernal instances.
+    Abstract base class for tools that update VersionKernel instances.
 
     This class provides a template for implementing tools that handle updates
-    of VersionKernal instances. A corresponding subclass of ParticleUpdater should be implemented
+    of VersionKernel instances. A corresponding subclass of ParticleUpdater should be implemented
     to manage the particle updates.
 
-    The following methods are called in sequence when updating a VersionKernal instance:
+    The following methods are called in sequence when updating a VersionKernel instance:
     
         1. `set_version_data`
         2. `set_particle_data`
@@ -178,12 +178,12 @@ class VersionUpdater(abc.ABC, Generic[Tvdata, Tpdata]):
     
 class ParticleUpdater(abc.ABC, Generic[Tvdata, Tpdata]):
     r"""
-    Abstract base class for tools that update ParticleKernal instances.
+    Abstract base class for tools that update ParticleKernel instances.
 
     This class provides a template for implementing tools that handle direct operations on particles
     when updating to the next version. The `run` method defines these operations.
 
-    The following methods are called in sequence when updating a ParticleKernal instance:
+    The following methods are called in sequence when updating a ParticleKernel instance:
     
         1. `set_version_data`
         2. `set_next_version_data`
@@ -249,7 +249,7 @@ class ParticleUpdater(abc.ABC, Generic[Tvdata, Tpdata]):
         return
     
     
-class VersionKernal(Generic[Tvdata, Tpdata]):
+class VersionKernel(Generic[Tvdata, Tpdata]):
     r"""
     Core class for managing versions of particle metadata.
 
@@ -262,7 +262,7 @@ class VersionKernal(Generic[Tvdata, Tpdata]):
             The VersionData subclass instance storing particle metadata, used to assist particle operations.
 
     Attributes:
-        next_version (Optional[VersionKernal[Tvdata, Tpdata]]): 
+        next_version (Optional[VersionKernel[Tvdata, Tpdata]]): 
             Points to the next version.
         particle_updater (Optional[ParticleUpdater[Tvdata, Tpdata]]): 
             Tool for updating particles within the current version.
@@ -272,7 +272,7 @@ class VersionKernal(Generic[Tvdata, Tpdata]):
     
     __slots__ = "next_version", "particle_updater", "data"
 
-    next_version: Optional[VersionKernal[Tvdata, Tpdata]]
+    next_version: Optional[VersionKernel[Tvdata, Tpdata]]
     particle_updater: Optional[ParticleUpdater[Tvdata, Tpdata]]
     data: Tvdata
     
@@ -286,10 +286,10 @@ class VersionKernal(Generic[Tvdata, Tpdata]):
         self.next_version = None
         self.particle_updater = None
         self.data = data
-        self.data.init_kernal(self)
+        self.data.init_kernel(self)
     
     def __repr__(self) -> str:
-        return f"VersionKernal({self.data})"
+        return f"VersionKernel({self.data})"
     
     @property
     def is_newest(self) -> bool:
@@ -317,7 +317,7 @@ class VersionKernal(Generic[Tvdata, Tpdata]):
         next_data, self.particle_updater = (version_updater.set_version_data(self.data)
                                                            .set_particle_data(particle_data)
                                                            .run(self.data))
-        self.next_version = VersionKernal(next_data)
+        self.next_version = VersionKernel(next_data)
         (self.particle_updater.set_version_data(self.data)
                               .set_next_version_data(next_data)
                               .set_particle_data(particle_data))
@@ -347,31 +347,31 @@ class VersionKernal(Generic[Tvdata, Tpdata]):
         self.next_version = None
         self.particle_updater = None
     
-    def copy(self) -> VersionKernal:
+    def copy(self) -> VersionKernel:
         """
         Creates a shallow copy of the current version.
 
         Returns:
             VersionKernel: A shallow copy of the current VersionKernel.
         """
-        return VersionKernal(self.data.copy())
+        return VersionKernel(self.data.copy())
         
 
-class ParticleKernal(Generic[Tvdata, Tpdata]):
+class ParticleKernel(Generic[Tvdata, Tpdata]):
     r"""
     Core class for managing particles.
 
-    Each `ParticleKernal` instance represents a particle, storing the particle's specific parameters.
+    Each `ParticleKernel` instance represents a particle, storing the particle's specific parameters.
     The particle's metadata is stored in the version instance pointed to by `version`.
 
     Args:
-        version (VersionKernal[Tvdata, Tpdata]):
+        version (VersionKernel[Tvdata, Tpdata]):
             Points to the corresponding version.
         data (Tpdata):
             The ParticleData subclass instance storing particle parameters, used to assist particle operations.
 
     Attributes:
-        version (VersionKernal[Tvdata, Tpdata]): 
+        version (VersionKernel[Tvdata, Tpdata]): 
             Points to the corresponding version.
         data (Tpdata): 
             The ParticleData subclass instance storing particle parameters, used to assist particle operations.
@@ -379,10 +379,10 @@ class ParticleKernal(Generic[Tvdata, Tpdata]):
     
     __slots__ = "version", "data"
 
-    version: VersionKernal[Tvdata, Tpdata]
+    version: VersionKernel[Tvdata, Tpdata]
     data: Tpdata
     
-    def __init__(self, version: VersionKernal[Tvdata, Tpdata], data: Tpdata) -> None:
+    def __init__(self, version: VersionKernel[Tvdata, Tpdata], data: Tpdata) -> None:
         """
         Initializes a `ParticleKernel` instance with the given version and data.
 
@@ -394,12 +394,12 @@ class ParticleKernal(Generic[Tvdata, Tpdata]):
         """
         self.version = version
         self.data = data
-        self.data.init_kernal(self)
+        self.data.init_kernel(self)
         
     def __repr__(self) -> str:
-        return f"ParticleKernal({self.data})"
+        return f"ParticleKernel({self.data})"
         
-    def create(self, data: Tpdata) -> ParticleKernal[Tvdata, Tpdata]:
+    def create(self, data: Tpdata) -> ParticleKernel[Tvdata, Tpdata]:
         """
         Creates a ParticleKernel belonging to the same species.
 
@@ -409,7 +409,7 @@ class ParticleKernal(Generic[Tvdata, Tpdata]):
         Returns:
             ParticleKernel[Tvdata, Tpdata]: A new ParticleKernel instance.
         """
-        return ParticleKernal(self.version, data)
+        return ParticleKernel(self.version, data)
     
     def version_update(self, version_updater: VersionUpdater[Tvdata, Tpdata]) -> None:
         """
@@ -443,7 +443,7 @@ class ParticleKernal(Generic[Tvdata, Tpdata]):
             self.version.particle_update(self.data)
             self.version = self.version.next_version
             
-    def detach(self) -> ParticleKernal[Tvdata, Tpdata]:
+    def detach(self) -> ParticleKernel[Tvdata, Tpdata]:
         """
         Detaches the current particle kernel instance to a new species.
 
@@ -453,7 +453,7 @@ class ParticleKernal(Generic[Tvdata, Tpdata]):
         Returns:
             ParticleKernel[Tvdata, Tpdata]: The detached ParticleKernel instance.
         """
-        return ParticleKernal(self.version.copy(),
+        return ParticleKernel(self.version.copy(),
                               self.data.copy(self.version.data))
 
 

--- a/nytorch/particle_updater.py
+++ b/nytorch/particle_updater.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from collections import OrderedDict
 from .base import NytoModuleBase, ParticleDataImp, VersionDataImp
-from .kernal import ParticleData, ParticleKernal, ParticleUpdater, VersionData
+from .kernel import ParticleData, ParticleKernel, ParticleUpdater, VersionData
 from .mtype import ConfigDict, MetaDict, Module, ModuleDict, ModuleID, ParamDict, ParamID, ParamType, ROOT_MODULE_ID
 from .utils import copy_modules, clone_param, clone_params, make_modules_ref
 from typing import Optional
@@ -86,7 +86,7 @@ class AddModuleParticleUpdater(ParticleUpdater[VersionDataImp, ParticleDataImp])
         for mid, mod in pdata.modules.items():
             if isinstance(mod, NytoModuleBase):
                 mod._module_id = mid
-                mod._particle_kernal = root_module._particle_kernal
+                mod._particle_kernel = root_module._particle_kernel
                 
 
 class AddParamParticleUpdater(ParticleUpdater[VersionDataImp, ParticleDataImp]):

--- a/nytorch/version_updater.py
+++ b/nytorch/version_updater.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from collections import ChainMap, OrderedDict
 from collections.abc import Iterable
 from .base import ParticleDataImp, VersionDataImp
-from .kernal import ParticleData, ParticleUpdater, VersionData, VersionUpdater
+from .kernel import ParticleData, ParticleUpdater, VersionData, VersionUpdater
 from .mtype import ConfigDict, MetaDict, Module, ModuleDict, ModuleID, ModuleMeta, ParamConfig, ParamDict, ParamID, ParamType
 from .particle_updater import AddModuleParticleUpdater, AddParamParticleUpdater, DelBufferParticleUpdater, DelModuleParticleUpdater, DelParamParticleUpdater, RegisterBufferParticleUpdater, SetModuleNoneParticleUpdater, SetParamNoneParticleUpdater
 from typing import Generic, Optional, TypeVar
@@ -12,7 +12,7 @@ import torch
 
 class AddModuleVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
     r"""
-    Updater for VersionKernal instances that adds a module to a particle.
+    Updater for VersionKernel instances that adds a module to a particle.
 
     This class facilitates the addition of a module to a particle by updating both version and particle data.
 
@@ -44,8 +44,8 @@ class AddModuleVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
         
         net0 = MyNet()
         net1 = MyNet()
-        particle_kernal: ParticleKernal = net0._particle_kernal
-        particle_kernal.version_update(AddModuleVersionUpdater(net0._module_id, 
+        particle_kernel: ParticleKernel = net0._particle_kernel
+        particle_kernel.version_update(AddModuleVersionUpdater(net0._module_id, 
                                                                "attar_net1", 
                                                                net1))
         
@@ -156,7 +156,7 @@ class AddModuleVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
 
 class AddParamVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
     r"""
-    Updater for VersionKernal instances that adds a parameter to a particle.
+    Updater for VersionKernel instances that adds a parameter to a particle.
 
     Args:
         module_id (ModuleID): 
@@ -185,8 +185,8 @@ class AddParamVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
         net = MyNet()
         add_param = torch.nn.Parameter(torch.randn(3, 3))
 
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(AddParamVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(AddParamVersionUpdater(net._module_id, 
                                                               "attar_add_param", 
                                                               add_param))
         
@@ -278,7 +278,7 @@ class AddParamVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
 
 class RegisterBufferVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
     r"""
-    Updater for VersionKernal instances that registers a buffer to a particle.
+    Updater for VersionKernel instances that registers a buffer to a particle.
 
     Args:
         module_id (ModuleID): 
@@ -308,8 +308,8 @@ class RegisterBufferVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataIm
         net = MyNet()
         add_tensor = torch.randn(3, 3)
 
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(RegisterBufferVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(RegisterBufferVersionUpdater(net._module_id, 
                                                                     "attar_add_tensor", 
                                                                     add_tensor))
         
@@ -372,7 +372,7 @@ class RegisterBufferVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataIm
 
 class SetModuleNoneVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
     r"""
-    Updater for VersionKernal instances that sets a module property in a particle to None.
+    Updater for VersionKernel instances that sets a module property in a particle to None.
 
     Args:
         module_id (ModuleID): 
@@ -393,8 +393,8 @@ class SetModuleNoneVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp
         
         net = MyNet()
         net.attar_module = MyNet()
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(SetModuleNoneVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(SetModuleNoneVersionUpdater(net._module_id, 
                                                                    "attar_module"))
         
         >>> net.attar_module is None
@@ -462,8 +462,8 @@ class SetParamNoneVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]
         
         net = MyNet()
         net.attar_param = torch.nn.Parameter(torch.randn(3, 3))
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(SetParamNoneVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(SetParamNoneVersionUpdater(net._module_id, 
                                                                   "attar_param"))
         
         >>> net.attar_param is None
@@ -530,8 +530,8 @@ class DelModuleVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
         
         net = MyNet()
         net.attar_moduel = MyNet()
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(DelModuleVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(DelModuleVersionUpdater(net._module_id, 
                                                                "attar_moduel"))
         
         >>> hasattr(net, "attar_moduel")
@@ -597,8 +597,8 @@ class DelParamVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
         
         net = MyNet()
         net.attar_param = torch.nn.Parameter(torch.randn(3, 3))
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(DelParamVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(DelParamVersionUpdater(net._module_id, 
                                                               "attar_moduel"))
         
         >>> hasattr(net, "attar_param")
@@ -661,8 +661,8 @@ class DelBufferVersionUpdater(VersionUpdater[VersionDataImp, ParticleDataImp]):
         
         net = MyNet()
         net.register_buffer("attar_buffer", torch.randn(3, 3))
-        particle_kernal: ParticleKernal = net._particle_kernal
-        particle_kernal.version_update(DelParamVersionUpdater(net._module_id, 
+        particle_kernel: ParticleKernel = net._particle_kernel
+        particle_kernel.version_update(DelParamVersionUpdater(net._module_id, 
                                                               "attar_buffer"))
         
         >>> hasattr(net, "attar_buffer")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as fh:
     long_description = "\n" + fh.read()
 
 setup(name='nytorch',
-      version="1.0",
+      version="1.0.1",
       author='jimmyzzzz',
       author_email='<sciencestudyjimmy@gmail.com>',
       description='Nytorch enhances PyTorch with advanced particle operations, seamlessly integrating new functionalities for effortless compatibility and enrichment.',

--- a/tests/test_PMProduct.py
+++ b/tests/test_PMProduct.py
@@ -5,17 +5,17 @@ import torch.nn as nn
 import unittest
 
 
-class TestSubModule(NytoModule):
+class MySubModule(NytoModule):
     def __init__(self, w2):
         super().__init__()
         self.param2 = nn.Parameter(torch.Tensor([w2]))
 
 
-class TestModule(NytoModule):
+class MyModule(NytoModule):
     def __init__(self, w1, w2):
         super().__init__()
         self.param1 = nn.Parameter(torch.Tensor([w1]))
-        self.sub_module = TestSubModule(w2)
+        self.sub_module = MySubModule(w2)
 
     @property
     def param2(self):
@@ -24,7 +24,7 @@ class TestModule(NytoModule):
 
 class TestPMProductOperateMethod(unittest.TestCase):
     def test_unary_operator(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         product1 = module1.product()
         module2 = product1.unary_operator(lambda param, conf: param+10).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
@@ -33,8 +33,8 @@ class TestPMProductOperateMethod(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([12.])))
 
     def test_binary_operator(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = ParticleModule(TestModule(3., 4.))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = ParticleModule(MyModule(3., 4.))
         module2 = module1.clone_from(module2)
         product1 = module1.product()
         product2 = module2.product()
@@ -48,7 +48,7 @@ class TestPMProductOperateMethod(unittest.TestCase):
 
 class TestPMProductOperation(unittest.TestCase):
     def test_neg(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (-module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -56,7 +56,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([-2.])))
         
     def test_pos(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (+module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -64,7 +64,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.])))
 
     def test_pow1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product() ** 2).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -72,7 +72,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.**2])))
 
     def test_pow2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (2 ** module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -80,7 +80,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2 ** 2.])))
         
     def test_pow3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module.product_(module.product() ** 2)
@@ -90,8 +90,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2.**2])))
 
     def test_pow4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = (module1.product() ** module2.product()).module()
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -101,8 +101,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.**4.])))
 
     def test_pow5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2.product_(module2.product() ** module1.product())
@@ -112,7 +112,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.**2.])))
     
     def test_add1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product() + 10).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -120,7 +120,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([12.])))
 
     def test_add2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (10 + module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -128,7 +128,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([12.])))
         
     def test_add3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module.product_(module.product() + 10)
@@ -138,8 +138,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([12.])))
 
     def test_add4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = (module1.product() + module2.product()).module()
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -149,8 +149,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.+4.])))
 
     def test_add5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2.product_(module2.product() + module1.product())
@@ -160,7 +160,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.+2.])))
     
     def test_sub1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product() - 10).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -168,7 +168,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. - 10])))
 
     def test_sub2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (10 - module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -176,7 +176,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 - 2.])))
         
     def test_sub3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module.product_(module.product() - 10)
@@ -186,8 +186,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. - 10])))
 
     def test_sub4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = (module1.product() - module2.product()).module()
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -197,8 +197,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.-4.])))
 
     def test_sub5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2.product_(module2.product() - module1.product())
@@ -208,7 +208,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.-2.])))
     
     def test_mul1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product() * 10).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -216,7 +216,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. * 10])))
 
     def test_mul2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (10 * module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -224,7 +224,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 * 2.])))
         
     def test_mul3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module.product_(module.product() * 10)
@@ -234,8 +234,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. * 10])))
 
     def test_mul4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = (module1.product() * module2.product()).module()
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -245,8 +245,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.*4.])))
 
     def test_mul5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2.product_(module2.product() * module1.product())
@@ -256,7 +256,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.*2.])))
 
     def test_truediv1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product() / 10).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -264,7 +264,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. / 10])))
 
     def test_truediv2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (10 / module1.product()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -272,7 +272,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 / 2.])))
         
     def test_truediv3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module.product_(module.product() / 10)
@@ -282,8 +282,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. / 10])))
 
     def test_truediv4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = (module1.product() / module2.product()).module()
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -293,8 +293,8 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2./4.])))
 
     def test_truediv5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2.product_(module2.product() / module1.product())
@@ -304,7 +304,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4./2.])))
 
     def test_clone(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product().clone()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -312,7 +312,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.])))
 
     def test_rand(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product().rand()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -324,7 +324,7 @@ class TestPMProductOperation(unittest.TestCase):
         self.assertTrue((module2.root_module.param2 <= 1).all())
 
     def test_randn(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = (module1.product().randn()).module()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)

--- a/tests/test_ParticleModule.py
+++ b/tests/test_ParticleModule.py
@@ -5,17 +5,17 @@ import torch.nn as nn
 import unittest
 
 
-class TestSubModule(NytoModule):
+class MySubModule(NytoModule):
     def __init__(self, w2):
         super().__init__()
         self.param2 = nn.Parameter(torch.Tensor([w2]))
 
 
-class TestModule(NytoModule):
+class MyModule(NytoModule):
     def __init__(self, w1, w2):
         super().__init__()
         self.param1 = nn.Parameter(torch.Tensor([w1]))
-        self.sub_module = TestSubModule(w2)
+        self.sub_module = MySubModule(w2)
 
     @property
     def param2(self):
@@ -24,31 +24,31 @@ class TestModule(NytoModule):
 
 class TestParticleModuleClearRef(unittest.TestCase):
     def test_init_clear_ref(self):
-        nyto_module = TestModule(1., 2.)
-        particle_kernal = nyto_module._particle_kernal
+        nyto_module = MyModule(1., 2.)
+        particle_kernel = nyto_module._particle_kernel
         particle_module = ParticleModule(nyto_module)
 
-        self.assertIsNone(nyto_module._particle_kernal)
-        self.assertIsNone(nyto_module.sub_module._particle_kernal)
+        self.assertIsNone(nyto_module._particle_kernel)
+        self.assertIsNone(nyto_module.sub_module._particle_kernel)
 
     def test_restore_and_clear_ref(self):
-        nyto_module = TestModule(1., 2.)
-        particle_kernal = nyto_module._particle_kernal
+        nyto_module = MyModule(1., 2.)
+        particle_kernel = nyto_module._particle_kernel
         particle_module = ParticleModule(nyto_module)
 
-        particle_module.restore_kernal_ref()
-        self.assertIs(nyto_module._particle_kernal, particle_kernal)
-        self.assertIs(nyto_module.sub_module._particle_kernal, particle_kernal)
+        particle_module.restore_kernel_ref()
+        self.assertIs(nyto_module._particle_kernel, particle_kernel)
+        self.assertIs(nyto_module.sub_module._particle_kernel, particle_kernel)
 
-        particle_module.clear_kernal_ref()
-        self.assertIsNone(nyto_module._particle_kernal)
-        self.assertIsNone(nyto_module.sub_module._particle_kernal)
+        particle_module.clear_kernel_ref()
+        self.assertIsNone(nyto_module._particle_kernel)
+        self.assertIsNone(nyto_module.sub_module._particle_kernel)
 
 
 class TestParticleModuleCloneFrom(unittest.TestCase):
     def test_clone_from1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = ParticleModule(TestModule(3., 4.))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = ParticleModule(MyModule(3., 4.))
         
         with self.assertRaises(Exception):
             module1 + module2
@@ -61,8 +61,8 @@ class TestParticleModuleCloneFrom(unittest.TestCase):
             module1 /= module2
 
     def test_clone_from2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = ParticleModule(TestModule(3., 4.))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = ParticleModule(MyModule(3., 4.))
 
         module3 = module1.clone_from(module2)
         self.assertIsNot(module2.root_module.param1, module3.root_module.param1)
@@ -73,7 +73,7 @@ class TestParticleModuleCloneFrom(unittest.TestCase):
 
 class TestParticleModuleTransform(unittest.TestCase):
     def test_transform(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         product = module.product()
         new_module = product.module()
 
@@ -85,7 +85,7 @@ class TestParticleModuleTransform(unittest.TestCase):
 
 class TestParticleModuleOperation(unittest.TestCase):
     def test_neg(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = -module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -93,7 +93,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([-2.])))
         
     def test_pos(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = +module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -101,7 +101,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.])))
 
     def test_pow1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1 ** 2
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -109,7 +109,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.**2])))
 
     def test_pow2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = 2 ** module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -117,7 +117,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2 ** 2.])))
         
     def test_pow3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module **= 2
@@ -127,8 +127,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2.**2])))
 
     def test_pow4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = module1 ** module2
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -138,8 +138,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.**4.])))
 
     def test_pow5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2 **= module1
@@ -149,7 +149,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.**2.])))
     
     def test_add1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1 + 10
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -157,7 +157,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([12.])))
 
     def test_add2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = 10 + module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -165,7 +165,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([12.])))
         
     def test_add3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module += 10
@@ -175,8 +175,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([12.])))
 
     def test_add4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = module1 + module2
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -186,8 +186,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.+4.])))
 
     def test_add5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2 += module1
@@ -197,7 +197,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.+2.])))
 
     def test_sub1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1 - 10
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -205,7 +205,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. - 10])))
 
     def test_sub2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = 10 - module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -213,7 +213,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 - 2.])))
         
     def test_sub3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module -= 10
@@ -223,8 +223,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. - 10])))
 
     def test_sub4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = module1 - module2
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -234,8 +234,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.-4.])))
 
     def test_sub5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2 -= module1
@@ -245,7 +245,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.-2.])))
 
     def test_mul1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1 * 10
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -253,7 +253,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. * 10])))
 
     def test_mul2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = 10 * module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -261,7 +261,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 * 2.])))
         
     def test_mul3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module *= 10
@@ -271,8 +271,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. * 10])))
 
     def test_mul4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = module1 * module2
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -282,8 +282,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2.*4.])))
 
     def test_mul5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2 *= module1
@@ -293,7 +293,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4.*2.])))
 
     def test_truediv1(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1 / 10
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -301,7 +301,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2. / 10])))
 
     def test_truediv2(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = 10 / module1
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -309,7 +309,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([10 / 2.])))
         
     def test_truediv3(self):
-        module = ParticleModule(TestModule(1., 2.))
+        module = ParticleModule(MyModule(1., 2.))
         module_param1 = module.root_module.param1
         module_param2 = module.root_module.param2
         module /= 10
@@ -319,8 +319,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module.root_module.param2, torch.Tensor([2. / 10])))
 
     def test_truediv4(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module3 = module1 / module2
         self.assertIsNot(module1.root_module.param1, module3.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module3.root_module.param2)
@@ -330,8 +330,8 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module3.root_module.param2, torch.Tensor([2./4.])))
 
     def test_truediv5(self):
-        module1 = ParticleModule(TestModule(1., 2.))
-        module2 = module1.clone_from(ParticleModule(TestModule(3., 4.)))
+        module1 = ParticleModule(MyModule(1., 2.))
+        module2 = module1.clone_from(ParticleModule(MyModule(3., 4.)))
         module2_param1 = module2.root_module.param1
         module2_param2 = module2.root_module.param2
         module2 /= module1
@@ -341,7 +341,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([4./2.])))
 
     def test_clone(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1.clone()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -349,7 +349,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue(torch.equal(module2.root_module.param2, torch.Tensor([2.])))
 
     def test_rand(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1.rand()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)
@@ -361,7 +361,7 @@ class TestParticleModuleOperation(unittest.TestCase):
         self.assertTrue((module2.root_module.param2 <= 1).all())
 
     def test_randn(self):
-        module1 = ParticleModule(TestModule(1., 2.))
+        module1 = ParticleModule(MyModule(1., 2.))
         module2 = module1.randn()
         self.assertIsNot(module1.root_module.param1, module2.root_module.param1)
         self.assertIsNot(module1.root_module.param2, module2.root_module.param2)

--- a/tests/test_circular_reference.py
+++ b/tests/test_circular_reference.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from nytorch import NytoModule
 from torch import nn
 from typing import Optional
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 
 import nytorch as nyto
 import unittest
@@ -37,9 +37,9 @@ class TestReference(unittest.TestCase):
             self.assertIn("modules from different particles refer to the same module", str(w[-1].message))
             
             root: RootModule = RootModule(b, c)
-            self.assertIs(root._particle_kernal, root.b._particle_kernal)
-            self.assertIs(root._particle_kernal, root.c._particle_kernal)
-            self.assertIs(root._particle_kernal, root.b.a._particle_kernal)
+            self.assertIs(root._particle_kernel, root.b._particle_kernel)
+            self.assertIs(root._particle_kernel, root.c._particle_kernel)
+            self.assertIs(root._particle_kernel, root.b.a._particle_kernel)
             self.assertEqual(root._module_id, nyto.mtype.ROOT_MODULE_ID)
             
             def assertModuleIDNotEquals(n, m_ls):

--- a/tests/test_clone_randn_detach.py
+++ b/tests/test_clone_randn_detach.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from nytorch import NytoModule
 from torch import nn
 from typing import Optional
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from unittest.mock import patch
 
 import numpy as np
@@ -23,26 +23,26 @@ class TestClone(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        root_clone: TestModule = root.clone()
+        root_clone: MyModule = root.clone()
         self.assertIsNot(root_clone, root)
         self.assertIsNot(root_clone.param1, root.param1)
         self.assertTrue(torch.equal(root_clone.param1, root.param1))
         self.assertIs(root_clone.buffer1, root.buffer1)
         self.assertIs(root_clone.data1, root.data1)
         
-        sub_module_clone: TestSubModule = root_clone.sub_module
+        sub_module_clone: MySubModule = root_clone.sub_module
         self.assertIsNot(sub_module_clone, sub_module)
         self.assertIsNot(sub_module_clone.param0, sub_module.param0)
         self.assertTrue(torch.equal(sub_module_clone.param0, sub_module.param0))
         self.assertIs(sub_module_clone.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_clone.data0, sub_module.data0)
         
-        self.assertIs(root_clone._particle_kernal, sub_module_clone._particle_kernal)
-        self.assertIsNot(root_clone._particle_kernal, root._particle_kernal)
-        self.assertIs(root_clone._version_kernal, root._version_kernal)
+        self.assertIs(root_clone._particle_kernel, sub_module_clone._particle_kernel)
+        self.assertIsNot(root_clone._particle_kernel, root._particle_kernel)
+        self.assertIs(root_clone._version_kernel, root._version_kernel)
         self.assertEqual(root_clone._module_id, root._module_id)
         self.assertEqual(sub_module_clone._module_id, sub_module._module_id)
         
@@ -55,26 +55,26 @@ class TestClone(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        sub_module_clone: TestSubModule = sub_module.clone()
+        sub_module_clone: MySubModule = sub_module.clone()
         self.assertIsNot(sub_module_clone, sub_module)
         self.assertIsNot(sub_module_clone.param0, sub_module.param0)
         self.assertTrue(torch.equal(sub_module_clone.param0, sub_module.param0))
         self.assertIs(sub_module_clone.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_clone.data0, sub_module.data0)
         
-        root_clone: TestModule = sub_module_clone._particle_kernal.data.modules[nyto.mtype.ROOT_MODULE_ID]
+        root_clone: MyModule = sub_module_clone._particle_kernel.data.modules[nyto.mtype.ROOT_MODULE_ID]
         self.assertIsNot(root_clone, root)
         self.assertIsNot(root_clone.param1, root.param1)
         self.assertTrue(torch.equal(root_clone.param1, root.param1))
         self.assertIs(root_clone.buffer1, root.buffer1)
         self.assertIs(root_clone.data1, root.data1)
         
-        self.assertIs(root_clone._particle_kernal, sub_module_clone._particle_kernal)
-        self.assertIsNot(root_clone._particle_kernal, root._particle_kernal)
-        self.assertIs(root_clone._version_kernal, root._version_kernal)
+        self.assertIs(root_clone._particle_kernel, sub_module_clone._particle_kernel)
+        self.assertIsNot(root_clone._particle_kernel, root._particle_kernel)
+        self.assertIs(root_clone._version_kernel, root._version_kernel)
         self.assertEqual(root_clone._module_id, root._module_id)
         self.assertEqual(sub_module_clone._module_id, sub_module._module_id)
 
@@ -96,7 +96,7 @@ class TestCloneFrom(unittest.TestCase):
         root2 = MyRoot()
         
         root3 = root1.clone_from(root2)
-        self.assertIs(root1._version_kernal, root3._version_kernal)
+        self.assertIs(root1._version_kernel, root3._version_kernel)
         self.assertTrue(torch.equal(root3.param, root2.param))
         self.assertTrue(torch.equal(root3.submodule.param, root2.submodule.param))
 
@@ -111,26 +111,26 @@ class TestRand(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        root_rand: TestModule = root.rand()
+        root_rand: MyModule = root.rand()
         self.assertIsNot(root_rand, root)
         self.assertIsNot(root_rand.param1, root.param1)
         self.assertTrue(root_rand.param1.shape, root.param1.shape)
         self.assertIs(root_rand.buffer1, root.buffer1)
         self.assertIs(root_rand.data1, root.data1)
         
-        sub_module_rand: TestSubModule = root_rand.sub_module
+        sub_module_rand: MySubModule = root_rand.sub_module
         self.assertIsNot(sub_module_rand, sub_module)
         self.assertIsNot(sub_module_rand.param0, sub_module.param0)
         self.assertEqual(sub_module_rand.param0.shape, sub_module.param0.shape)
         self.assertIs(sub_module_rand.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_rand.data0, sub_module.data0)
         
-        self.assertIs(root_rand._particle_kernal, sub_module_rand._particle_kernal)
-        self.assertIsNot(root_rand._particle_kernal, root._particle_kernal)
-        self.assertIs(root_rand._version_kernal, root._version_kernal)
+        self.assertIs(root_rand._particle_kernel, sub_module_rand._particle_kernel)
+        self.assertIsNot(root_rand._particle_kernel, root._particle_kernel)
+        self.assertIs(root_rand._version_kernel, root._version_kernel)
         self.assertEqual(root_rand._module_id, root._module_id)
         self.assertEqual(sub_module_rand._module_id, sub_module._module_id)   
     
@@ -143,26 +143,26 @@ class TestRand(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        sub_module_rand: TestSubModule = sub_module.rand()
+        sub_module_rand: MySubModule = sub_module.rand()
         self.assertIsNot(sub_module_rand, sub_module)
         self.assertIsNot(sub_module_rand.param0, sub_module.param0)
         self.assertTrue(sub_module_rand.param0.shape, sub_module.param0.shape)
         self.assertIs(sub_module_rand.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_rand.data0, sub_module.data0)
         
-        root_rand: TestModule = sub_module_rand._particle_kernal.data.modules[nyto.mtype.ROOT_MODULE_ID]
+        root_rand: MyModule = sub_module_rand._particle_kernel.data.modules[nyto.mtype.ROOT_MODULE_ID]
         self.assertIsNot(root_rand, root)
         self.assertIsNot(root_rand.param1, root.param1)
         self.assertTrue(root_rand.param1.shape, root.param1.shape)
         self.assertIs(root_rand.buffer1, root.buffer1)
         self.assertIs(root_rand.data1, root.data1)
         
-        self.assertIs(root_rand._particle_kernal, sub_module_rand._particle_kernal)
-        self.assertIsNot(root_rand._particle_kernal, root._particle_kernal)
-        self.assertIs(root_rand._version_kernal, root._version_kernal)
+        self.assertIs(root_rand._particle_kernel, sub_module_rand._particle_kernel)
+        self.assertIsNot(root_rand._particle_kernel, root._particle_kernel)
+        self.assertIs(root_rand._version_kernel, root._version_kernel)
         self.assertEqual(root_rand._module_id, root._module_id)
         self.assertEqual(sub_module_rand._module_id, sub_module._module_id)
 
@@ -177,26 +177,26 @@ class TestRandn(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        root_randn: TestModule = root.randn()
+        root_randn: MyModule = root.randn()
         self.assertIsNot(root_randn, root)
         self.assertIsNot(root_randn.param1, root.param1)
         self.assertTrue(root_randn.param1.shape, root.param1.shape)
         self.assertIs(root_randn.buffer1, root.buffer1)
         self.assertIs(root_randn.data1, root.data1)
         
-        sub_module_randn: TestSubModule = root_randn.sub_module
+        sub_module_randn: MySubModule = root_randn.sub_module
         self.assertIsNot(sub_module_randn, sub_module)
         self.assertIsNot(sub_module_randn.param0, sub_module.param0)
         self.assertEqual(sub_module_randn.param0.shape, sub_module.param0.shape)
         self.assertIs(sub_module_randn.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_randn.data0, sub_module.data0)
         
-        self.assertIs(root_randn._particle_kernal, sub_module_randn._particle_kernal)
-        self.assertIsNot(root_randn._particle_kernal, root._particle_kernal)
-        self.assertIs(root_randn._version_kernal, root._version_kernal)
+        self.assertIs(root_randn._particle_kernel, sub_module_randn._particle_kernel)
+        self.assertIsNot(root_randn._particle_kernel, root._particle_kernel)
+        self.assertIs(root_randn._version_kernel, root._version_kernel)
         self.assertEqual(root_randn._module_id, root._module_id)
         self.assertEqual(sub_module_randn._module_id, sub_module._module_id)   
     
@@ -209,26 +209,26 @@ class TestRandn(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        sub_module_randn: TestSubModule = sub_module.randn()
+        sub_module_randn: MySubModule = sub_module.randn()
         self.assertIsNot(sub_module_randn, sub_module)
         self.assertIsNot(sub_module_randn.param0, sub_module.param0)
         self.assertTrue(sub_module_randn.param0.shape, sub_module.param0.shape)
         self.assertIs(sub_module_randn.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_randn.data0, sub_module.data0)
         
-        root_randn: TestModule = sub_module_randn._particle_kernal.data.modules[nyto.mtype.ROOT_MODULE_ID]
+        root_randn: MyModule = sub_module_randn._particle_kernel.data.modules[nyto.mtype.ROOT_MODULE_ID]
         self.assertIsNot(root_randn, root)
         self.assertIsNot(root_randn.param1, root.param1)
         self.assertTrue(root_randn.param1.shape, root.param1.shape)
         self.assertIs(root_randn.buffer1, root.buffer1)
         self.assertIs(root_randn.data1, root.data1)
         
-        self.assertIs(root_randn._particle_kernal, sub_module_randn._particle_kernal)
-        self.assertIsNot(root_randn._particle_kernal, root._particle_kernal)
-        self.assertIs(root_randn._version_kernal, root._version_kernal)
+        self.assertIs(root_randn._particle_kernel, sub_module_randn._particle_kernel)
+        self.assertIsNot(root_randn._particle_kernel, root._particle_kernel)
+        self.assertIs(root_randn._version_kernel, root._version_kernel)
         self.assertEqual(root_randn._module_id, root._module_id)
         self.assertEqual(sub_module_randn._module_id, sub_module._module_id)
         
@@ -243,24 +243,24 @@ class TestDetach(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        root_detach: TestModule = root.detach()
+        root_detach: MyModule = root.detach()
         self.assertIsNot(root_detach, root)
         self.assertIs(root_detach.param1, root.param1)
         self.assertIs(root_detach.buffer1, root.buffer1)
         self.assertIs(root_detach.data1, root.data1)
         
-        sub_module_detach: TestSubModule = root_detach.sub_module
+        sub_module_detach: MySubModule = root_detach.sub_module
         self.assertIsNot(sub_module_detach, sub_module)
         self.assertIs(sub_module_detach.param0, sub_module.param0)
         self.assertIs(sub_module_detach.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_detach.data0, sub_module.data0)
         
-        self.assertIs(root_detach._particle_kernal, sub_module_detach._particle_kernal)
-        self.assertIsNot(root_detach._particle_kernal, root._particle_kernal)
-        self.assertIsNot(root_detach._version_kernal, root._version_kernal)
+        self.assertIs(root_detach._particle_kernel, sub_module_detach._particle_kernel)
+        self.assertIsNot(root_detach._particle_kernel, root._particle_kernel)
+        self.assertIsNot(root_detach._version_kernel, root._version_kernel)
         self.assertEqual(root_detach._module_id, root._module_id)
         self.assertEqual(sub_module_detach._module_id, sub_module._module_id)
         
@@ -273,24 +273,24 @@ class TestDetach(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        sub_module_detach: TestSubModule = sub_module.detach()
+        sub_module_detach: MySubModule = sub_module.detach()
         self.assertIsNot(sub_module_detach, sub_module)
         self.assertIs(sub_module_detach.param0, sub_module.param0)
         self.assertIs(sub_module_detach.buffer0, sub_module.buffer0)
         self.assertIs(sub_module_detach.data0, sub_module.data0)
         
-        root_detach: TestModule = sub_module_detach._particle_kernal.data.modules[nyto.mtype.ROOT_MODULE_ID]
+        root_detach: MyModule = sub_module_detach._particle_kernel.data.modules[nyto.mtype.ROOT_MODULE_ID]
         self.assertIsNot(root_detach, root)
         self.assertIs(root_detach.param1, root.param1)
         self.assertIs(root_detach.buffer1, root.buffer1)
         self.assertIs(root_detach.data1, root.data1)
         
-        self.assertIs(root_detach._particle_kernal, sub_module_detach._particle_kernal)
-        self.assertIsNot(root_detach._particle_kernal, root._particle_kernal)
-        self.assertIsNot(root_detach._version_kernal, root._version_kernal)
+        self.assertIs(root_detach._particle_kernel, sub_module_detach._particle_kernel)
+        self.assertIsNot(root_detach._particle_kernel, root._particle_kernel)
+        self.assertIsNot(root_detach._version_kernel, root._version_kernel)
         self.assertEqual(root_detach._module_id, root._module_id)
         self.assertEqual(sub_module_detach._module_id, sub_module._module_id)
 
@@ -312,8 +312,8 @@ class TestGetParamId(unittest.TestCase):
         root_param_id = root.get_param_id(root.param)
         submodule_param_id = root.get_param_id(root.submodule.param)
         
-        self.assertIs(root._particle_kernal.data.params[root_param_id], root.param)
-        self.assertIs(root._particle_kernal.data.params[submodule_param_id], root.submodule.param)
+        self.assertIs(root._particle_kernel.data.params[root_param_id], root.param)
+        self.assertIs(root._particle_kernel.data.params[submodule_param_id], root.submodule.param)
         
     def test_get_param_id2(self):
         class MyModule(NytoModule):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from nytorch.module import ParamProduct
 from nytorch.mtype import ModuleID, ParamConfig, ParamDict, ParamType
@@ -18,8 +18,8 @@ def create_new_root() -> NytoModule:
     data0: UserData = UserData()
     data1: UserData = UserData()
 
-    sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-    root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+    sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+    root: MyModule = MyModule(param1, sub_module, buffer1, data1)
     
     return root
 

--- a/tests/test_convert_attar_type.py
+++ b/tests/test_convert_attar_type.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from torch import nn
 import unittest
@@ -13,52 +13,52 @@ class TestConvertParam(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
 
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception): 
             module.param0 = nn.Linear(2, 3)
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
             
     def test_param_to_buffer(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception): 
             module.register_buffer("param0", torch.randn(1))
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
         
     def test_param_to_value(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
 
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception):
             module.param0 = UserData()
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
         
     def test_param_to_none(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
 
         module.param0 = None
         
@@ -78,7 +78,7 @@ class TestConvertModule(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
         other_param: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         module.lin = other_param
@@ -97,37 +97,37 @@ class TestConvertModule(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception): 
             module.register_buffer("lin", torch.randn(1))
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
         
     def test_module_to_value(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception): 
             module.lin = UserData()
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
         
     def test_module_to_none(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
 
         module.lin = None
         
@@ -147,7 +147,7 @@ class TestConvertBuffer(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
         other_lin: nn.Linear = nn.Linear(2, 3)
         module.buffer0 = other_lin
@@ -166,7 +166,7 @@ class TestConvertBuffer(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
         other_param: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         module.buffer0 = other_param
@@ -185,22 +185,22 @@ class TestConvertBuffer(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception): 
             module.buffer0 = UserData()
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)
         
     def test_buffer_to_none(self):
         param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
 
         module.buffer0 = None
         
@@ -220,7 +220,7 @@ class TestConvertValue(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
         other_lin: nn.Linear = nn.Linear(2, 3)
         module.data0 = other_lin
@@ -239,7 +239,7 @@ class TestConvertValue(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
         other_param: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         module.data0 = other_param
@@ -258,12 +258,12 @@ class TestConvertValue(unittest.TestCase):
         buffer0: torch.Tensor = torch.randn(1)
         lin: nn.Linear = nn.Linear(2, 3)
         data0: UserData = UserData()
-        module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
+        module: MySubModule = MySubModule(param0, lin, buffer0, data0)
         
-        vkernal: nyto.kernal.VersionKernal = module._version_kernal
-        self.assertTrue(vkernal.is_newest)
+        vkernel: nyto.kernel.VersionKernel = module._version_kernel
+        self.assertTrue(vkernel.is_newest)
         
         with self.assertRaises(Exception):
             module.register_buffer("data0", torch.randn(1))
             
-        self.assertIs(module._version_kernal, vkernal)
+        self.assertIs(module._version_kernel, vkernel)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from torch import nn
 import unittest
@@ -16,10 +16,10 @@ class TestInit(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, param1)
@@ -66,10 +66,10 @@ class TestInit2(unittest.TestCase):
         module.register_buffer("buffer1", buffer1)
         module.data1 = data1
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, param1)

--- a/tests/test_module_operator.py
+++ b/tests/test_module_operator.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from nytorch.module import ParamProduct
 from nytorch.mtype import ParamType, ParamConfig
@@ -30,58 +30,58 @@ def create_new_root() -> NytoModule:
     data0: UserData = UserData()
     data1: UserData = UserData()
 
-    sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-    root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+    sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+    root: MyModule = MyModule(param1, sub_module, buffer1, data1)
     
     return root
 
 
-class TestModuleNegOperate(unittest.TestCase):
+class MyModuleNegOperate(unittest.TestCase):
     def test_module_neg_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (-root.product()).module()
-        test_root: TestModule = -root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (-root.product()).module()
+        test_root: MyModule = -root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_pos_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (+root.product()).module()
-        test_root: TestModule = +root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (+root.product()).module()
+        test_root: MyModule = +root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
-class TestModulePowOperate(unittest.TestCase):
+class MyModulePowOperate(unittest.TestCase):
     def test_module_pow_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (root.product() ** 1.5).module()
-        test_root: TestModule = root ** 1.5
+        root: MyModule = create_new_root()
+        target_root: MyModule = (root.product() ** 1.5).module()
+        test_root: MyModule = root ** 1.5
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_pow_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (1.5 ** root.product()).module()
-        test_root: TestModule = 1.5 ** root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (1.5 ** root.product()).module()
+        test_root: MyModule = 1.5 ** root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_pow_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        target_root: TestModule = (root1.product() ** root2.product()).module()
-        test_root: TestModule = root1 ** root2
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        target_root: MyModule = (root1.product() ** root2.product()).module()
+        test_root: MyModule = root1 ** root2
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
     def test_module_pow_operator4(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
         
         with self.assertRaises(Exception):
             root1 ** root2.product()
@@ -90,35 +90,35 @@ class TestModulePowOperate(unittest.TestCase):
             root1.product() ** root2
             
             
-class TestModuleAddOperate(unittest.TestCase):
+class MyModuleAddOperate(unittest.TestCase):
     def test_module_add_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (root.product() + 1.5).module()
-        test_root: TestModule = root + 1.5
+        root: MyModule = create_new_root()
+        target_root: MyModule = (root.product() + 1.5).module()
+        test_root: MyModule = root + 1.5
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_add_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (1.5 + root.product()).module()
-        test_root: TestModule = 1.5 + root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (1.5 + root.product()).module()
+        test_root: MyModule = 1.5 + root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_add_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        target_root: TestModule = (root1.product() + root2.product()).module()
-        test_root: TestModule = root1 + root2
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        target_root: MyModule = (root1.product() + root2.product()).module()
+        test_root: MyModule = root1 + root2
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
     def test_module_add_operator4(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
         
         with self.assertRaises(Exception):
             root1 + root2.product()
@@ -127,35 +127,35 @@ class TestModuleAddOperate(unittest.TestCase):
             root1.product() + root2
         
         
-class TestModuleSubOperate(unittest.TestCase):
+class MyModuleSubOperate(unittest.TestCase):
     def test_module_sub_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (root.product() - 1.5).module()
-        test_root: TestModule = root - 1.5
+        root: MyModule = create_new_root()
+        target_root: MyModule = (root.product() - 1.5).module()
+        test_root: MyModule = root - 1.5
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_sub_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (1.5 - root.product()).module()
-        test_root: TestModule = 1.5 - root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (1.5 - root.product()).module()
+        test_root: MyModule = 1.5 - root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_sub_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        target_root: TestModule = (root1.product() - root2.product()).module()
-        test_root: TestModule = root1 - root2
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        target_root: MyModule = (root1.product() - root2.product()).module()
+        test_root: MyModule = root1 - root2
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
     def test_module_sub_operator4(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
         
         with self.assertRaises(Exception):
             root1 - root2.product()
@@ -164,35 +164,35 @@ class TestModuleSubOperate(unittest.TestCase):
             root1.product() - root2
             
 
-class TestModuleMulOperate(unittest.TestCase):
+class MyModuleMulOperate(unittest.TestCase):
     def test_module_mul_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (root.product() * 1.5).module()
-        test_root: TestModule = root * 1.5
+        root: MyModule = create_new_root()
+        target_root: MyModule = (root.product() * 1.5).module()
+        test_root: MyModule = root * 1.5
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_mul_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (1.5 * root.product()).module()
-        test_root: TestModule = 1.5 * root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (1.5 * root.product()).module()
+        test_root: MyModule = 1.5 * root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_mul_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        target_root: TestModule = (root1.product() * root2.product()).module()
-        test_root: TestModule = root1 * root2
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        target_root: MyModule = (root1.product() * root2.product()).module()
+        test_root: MyModule = root1 * root2
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
     def test_module_mul_operator4(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
         
         with self.assertRaises(Exception):
             root1 * root2.product()
@@ -201,35 +201,35 @@ class TestModuleMulOperate(unittest.TestCase):
             root1.product() * root2
             
             
-class TestModuleTruedivOperate(unittest.TestCase):
+class MyModuleTruedivOperate(unittest.TestCase):
     def test_module_truediv_operator1(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (root.product() / 1.5).module()
-        test_root: TestModule = root / 1.5
+        root: MyModule = create_new_root()
+        target_root: MyModule = (root.product() / 1.5).module()
+        test_root: MyModule = root / 1.5
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_truediv_operator2(self):
-        root: TestModule = create_new_root()
-        target_root: TestModule = (1.5 / root.product()).module()
-        test_root: TestModule = 1.5 / root
+        root: MyModule = create_new_root()
+        target_root: MyModule = (1.5 / root.product()).module()
+        test_root: MyModule = 1.5 / root
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
         
     def test_module_truediv_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        target_root: TestModule = (root1.product() / root2.product()).module()
-        test_root: TestModule = root1 / root2
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        target_root: MyModule = (root1.product() / root2.product()).module()
+        test_root: MyModule = root1 / root2
         
         self.assertTrue(params_equal_check(OrderedDict(target_root.named_parameters()),
                                            OrderedDict(test_root.named_parameters())))
 
     def test_module_truediv_operator4(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
         
         with self.assertRaises(Exception):
             root1 / root2.product()

--- a/tests/test_opertaor_with_config.py
+++ b/tests/test_opertaor_with_config.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from nytorch.module import ParamProduct
 from nytorch.mtype import ParamType, ParamConfig

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from nytorch.module import ParamProduct
 from torch import nn
@@ -18,8 +18,8 @@ class TestProductConvert(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         root_product: ParamProduct = root.product()
         param_set: set[nn.Parameter] = {param0, param1, lin.weight, lin.bias}
@@ -50,15 +50,15 @@ class TestProductConvert(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        root: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         sub_module_product: ParamProduct = sub_module.product()
         param_set: set[nn.Parameter] = {param0, param1, lin.weight, lin.bias}
         self.assertEqual(param_set, set(sub_module_product.params.values()))
         
         sub_module_copy: RootModule = sub_module_product.module()
-        root_copy: RootModule = sub_module_copy._particle_kernal.data.modules[nyto.mtype.ROOT_MODULE_ID]
+        root_copy: RootModule = sub_module_copy._particle_kernel.data.modules[nyto.mtype.ROOT_MODULE_ID]
         
         self.assertIsNot(root, root_copy)
         self.assertTrue(torch.equal(root.param1, root_copy.param1))

--- a/tests/test_product_operate.py
+++ b/tests/test_product_operate.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from nytorch.module import ParamProduct
 from nytorch.mtype import ParamType, ParamConfig
@@ -105,16 +105,16 @@ def create_new_root() -> NytoModule:
     data0: UserData = UserData()
     data1: UserData = UserData()
 
-    sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-    root: TestModule = TestModule(param1, sub_module, buffer1, data1)
+    sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+    root: MyModule = MyModule(param1, sub_module, buffer1, data1)
     
     return root
 
 
 class TestProductOperateMethod(unittest.TestCase):
     def test_product_unary_operator(self):
-        root: TestModule = create_new_root()
-        add_one_root: TestModule = (root.product()
+        root: MyModule = create_new_root()
+        add_one_root: MyModule = (root.product()
                                         .unary_operator(lambda param, conf: param+1)
                                         .module())
         
@@ -126,9 +126,9 @@ class TestProductOperateMethod(unittest.TestCase):
                                            add_one_dict))
 
     def test_product_binary_operator(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.clone()
-        add_root: TestModule = (root1.product() 
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.clone()
+        add_root: MyModule = (root1.product() 
                                      .binary_operator(root2.product(), 
                                                       lambda param1, param2, conf: param1+param2)
                                      .module())
@@ -147,8 +147,8 @@ class TestProductOperateMethod(unittest.TestCase):
         
 class TestProductNegOperate(unittest.TestCase):
     def test_product_pos_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (+root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (+root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param) for name, param in root.named_parameters())
@@ -157,8 +157,8 @@ class TestProductNegOperate(unittest.TestCase):
                                            manual_dict))
         
     def test_product_neg_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (-root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (-root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, -param) for name, param in root.named_parameters())
@@ -169,8 +169,8 @@ class TestProductNegOperate(unittest.TestCase):
         
 class TestProductPowOperate(unittest.TestCase):
     def test_product_pow_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (root.product() ** 1.2).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (root.product() ** 1.2).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param**1.2) for name, param in root.named_parameters())
@@ -179,8 +179,8 @@ class TestProductPowOperate(unittest.TestCase):
                                            manual_dict))
 
     def test_product_pow_operator2(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (1.2 ** root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (1.2 ** root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, 1.2**param) for name, param in root.named_parameters())
@@ -189,9 +189,9 @@ class TestProductPowOperate(unittest.TestCase):
                                            manual_dict))
     
     def test_product_pow_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        new_root: TestModule = (root1.product() ** root2.product()).module()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        new_root: MyModule = (root1.product() ** root2.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict()
@@ -206,8 +206,8 @@ class TestProductPowOperate(unittest.TestCase):
         
 class TestProductAddOperate(unittest.TestCase):
     def test_product_add_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (root.product() + 1).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (root.product() + 1).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param+1) for name, param in root.named_parameters())
@@ -216,8 +216,8 @@ class TestProductAddOperate(unittest.TestCase):
                                            manual_dict))
 
     def test_product_add_operator2(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (1 + root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (1 + root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, 1+param) for name, param in root.named_parameters())
@@ -226,9 +226,9 @@ class TestProductAddOperate(unittest.TestCase):
                                            manual_dict))
     
     def test_product_add_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        new_root: TestModule = (root1.product() + root2.product()).module()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        new_root: MyModule = (root1.product() + root2.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict()
@@ -243,8 +243,8 @@ class TestProductAddOperate(unittest.TestCase):
 
 class TestProductSubOperate(unittest.TestCase):
     def test_product_sub_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (root.product() - 1).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (root.product() - 1).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param-1) for name, param in root.named_parameters())
@@ -253,8 +253,8 @@ class TestProductSubOperate(unittest.TestCase):
                                            manual_dict))
 
     def test_product_sub_operator2(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (1 - root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (1 - root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, 1-param) for name, param in root.named_parameters())
@@ -263,9 +263,9 @@ class TestProductSubOperate(unittest.TestCase):
                                            manual_dict))
     
     def test_product_sub_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        new_root: TestModule = (root1.product() - root2.product()).module()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        new_root: MyModule = (root1.product() - root2.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict()
@@ -280,8 +280,8 @@ class TestProductSubOperate(unittest.TestCase):
         
 class TestProductMulOperate(unittest.TestCase):
     def test_product_mul_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (root.product() * 1.5).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (root.product() * 1.5).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param*1.5) for name, param in root.named_parameters())
@@ -290,8 +290,8 @@ class TestProductMulOperate(unittest.TestCase):
                                            manual_dict))
 
     def test_product_mul_operator2(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (1.5 * root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (1.5 * root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, 1.5*param) for name, param in root.named_parameters())
@@ -300,9 +300,9 @@ class TestProductMulOperate(unittest.TestCase):
                                            manual_dict))
     
     def test_product_mul_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        new_root: TestModule = (root1.product() * root2.product()).module()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        new_root: MyModule = (root1.product() * root2.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict()
@@ -317,8 +317,8 @@ class TestProductMulOperate(unittest.TestCase):
         
 class TestProductTruedivOperate(unittest.TestCase):
     def test_product_truediv_operator1(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (root.product() / 1.5).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (root.product() / 1.5).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, param/1.5) for name, param in root.named_parameters())
@@ -327,8 +327,8 @@ class TestProductTruedivOperate(unittest.TestCase):
                                            manual_dict))
 
     def test_product_truediv_operator2(self):
-        root: TestModule = create_new_root()
-        new_root: TestModule = (1.5 / root.product()).module()
+        root: MyModule = create_new_root()
+        new_root: MyModule = (1.5 / root.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict((name, 1.5/param) for name, param in root.named_parameters())
@@ -337,9 +337,9 @@ class TestProductTruedivOperate(unittest.TestCase):
                                            manual_dict))
     
     def test_product_truediv_operator3(self):
-        root1: TestModule = create_new_root()
-        root2: TestModule = root1.randn()
-        new_root: TestModule = (root1.product() / root2.product()).module()
+        root1: MyModule = create_new_root()
+        root2: MyModule = root1.randn()
+        new_root: MyModule = (root1.product() / root2.product()).module()
         
         with torch.no_grad():
             manual_dict = OrderedDict()

--- a/tests/test_reset_attar.py
+++ b/tests/test_reset_attar.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from torch import nn
 import unittest
@@ -17,8 +17,8 @@ class TestResetAttar(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         reset_param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         reset_param1: nn.Parameter = nn.Parameter(torch.randn(3, 3))
@@ -26,7 +26,7 @@ class TestResetAttar(unittest.TestCase):
         sub_module.param0 = reset_param0
         module.param1 = reset_param1
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, reset_param1)
@@ -56,8 +56,8 @@ class TestResetAttar(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         reset_buffer0: torch.Tensor = torch.randn(1)
         reset_buffer1: torch.Tensor = torch.randn(1)
@@ -65,7 +65,7 @@ class TestResetAttar(unittest.TestCase):
         sub_module.buffer0 = reset_buffer0
         module.buffer1 = reset_buffer1
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, param1)
@@ -95,13 +95,13 @@ class TestResetAttar(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         reset_lin: nn.Linear = nn.Linear(2, 3)
         sub_module.lin = reset_lin
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, param1)
@@ -131,17 +131,17 @@ class TestResetAttar(unittest.TestCase):
         data0: UserData = UserData()
         data1: UserData = UserData()
         
-        sub_module: TestSubModule = TestSubModule(param0, lin, buffer0, data0)
-        module: TestModule = TestModule(param1, sub_module, buffer1, data1)
+        sub_module: MySubModule = MySubModule(param0, lin, buffer0, data0)
+        module: MyModule = MyModule(param1, sub_module, buffer1, data1)
         
         reset_param0: nn.Parameter = nn.Parameter(torch.randn(2, 2))
         reset_lin: nn.Linear = nn.Linear(2, 3)
         reset_buffer0: torch.Tensor = torch.randn(1)
         reset_data0: UserData = UserData()
-        reset_sub_module: TestSubModule = TestSubModule(reset_param0, reset_lin, reset_buffer0, reset_data0)
+        reset_sub_module: MySubModule = MySubModule(reset_param0, reset_lin, reset_buffer0, reset_data0)
         module.sub_module = reset_sub_module
         
-        self.assertIs(module._particle_kernal, module.sub_module._particle_kernal)
+        self.assertIs(module._particle_kernel, module.sub_module._particle_kernel)
         self.assertNotEqual(module._module_id, module.sub_module._module_id)
         
         self.assertIs(module.param1, param1)

--- a/tests/test_version_update.py
+++ b/tests/test_version_update.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from .utils import TestModule, TestSubModule, UserData
+from .utils import MyModule, MySubModule, UserData
 from nytorch import NytoModule
 from torch import nn
 import unittest
@@ -58,11 +58,11 @@ class TestAddAttar(unittest.TestCase):
         root_randn: RootModule = root.randn()
         root_detach: RootModule = root.detach()
         
-        root.lin0: TestSubModule = TestSubModule(param=nn.Parameter(torch.randn(2, 2)),
+        root.lin0: MySubModule = MySubModule(param=nn.Parameter(torch.randn(2, 2)),
                                                  lin=nn.Linear(3, 2),
                                                  buffer=torch.randn(1),
                                                  data=UserData())
-        root.sub_module.lin1: TestSubModule = TestSubModule(param=nn.Parameter(torch.randn(2, 2)),
+        root.sub_module.lin1: MySubModule = MySubModule(param=nn.Parameter(torch.randn(2, 2)),
                                                             lin=nn.Linear(3, 2),
                                                             buffer=torch.randn(1),
                                                             data=UserData())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ class UserData:
     pass
 
 
-class TestSubModule(NytoModule):
+class MySubModule(NytoModule):
     def __init__(self, param: nn.Parameter, lin: nn.Linear, buffer: torch.Tensor, data: UserData):
         super().__init__()
         self.param0: nn.Parameter = param
@@ -19,7 +19,7 @@ class TestSubModule(NytoModule):
         return self.lin(x) + self.param0
     
 
-class TestModule(NytoModule):
+class MyModule(NytoModule):
     def __init__(self, param: nn.Parameter, sub_module: NytoModule, buffer: torch.Tensor, data: UserData):
         super().__init__()
         self.param1: nn.Parameter = param


### PR DESCRIPTION
…onding tests and documentation:

- Corrected spelling mistakes in method and variable names:
  - `ParticleKernal` -> `ParticleKernel`
  - `VersionKernal` -> `VersionKernel`
  - `ParticleModule.restore_kernal_ref` -> `ParticleModule.restore_kernel_ref`
  - `ParticleModule.clear_kernal_ref` -> `ParticleModule.clear_kernel_ref`
- Updated the following test files to reflect these name changes and ensure tests pass:
  - `tests/test_PMProduct.py`
  - `tests/test_ParticleModule.py`
  - `tests/test_clone_randn_detach.py`
  - `tests/test_circular_reference.py`
  - `tests/test_config.py`
  - `tests/test_convert_attar_type.py`
  - `tests/test_init.py`
  - `tests/test_module_operator.py`
  - `tests/test_opertaor_with_config.py`
  - `tests/test_product.py`
  - `tests/test_product_operate.py`
  - `tests/test_reset_attar.py`
  - `tests/test_version_update.py`
  - `tests/utils.py`
- Renamed test-related objects in test files to prevent pytest from misidentifying them as test cases:
  - `TestModule` -> `MyModule`
  - `TestSubModule` -> `MySubModule`
- Removed `nytorch/kernal.py` and added `nytorch/kernel.py` to fix the spelling inconsistency.
- Updated documentation to reflect the name changes in the following files:
  - `docs/ParticleModule.rst`
  - `docs/conf.py`
  - `docs/nytorch.rst`
  - `docs/particle.rst`
  - `docs/particle_version.rst`
- Updated version number in `setup.py` and `docs/conf.py` to reflect these changes.

Changes:
- Modified: `nytorch/__init__.py`, `nytorch/base.py`, `nytorch/module.py`, `nytorch/particle_module.py`, `nytorch/particle_updater.py`, `nytorch/version_updater.py`, `setup.py`, `docs/conf.py`
- New file: `nytorch/kernel.py`
- Deleted: `nytorch/kernal.py`
- Updated tests: `tests/test_PMProduct.py`, `tests/test_ParticleModule.py`, `tests/test_clone_randn_detach.py`, `tests/test_circular_reference.py`, `tests/test_config.py`, `tests/test_convert_attar_type.py`, `tests/test_init.py`, `tests/test_module_operator.py`, `tests/test_opertaor_with_config.py`, `tests/test_product.py`, `tests/test_product_operate.py`, `tests/test_reset_attar.py`, `tests/test_version_update.py`, `tests/utils.py`
- Updated documentation: `docs/ParticleModule.rst`, `docs/conf.py`, `docs/nytorch.rst`, `docs/particle.rst`, `docs/particle_version.rst`